### PR TITLE
feat(CloudX): 2nd task 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+CloudFront URL https://d1bmxna8i2i9rw.cloudfront.net/
+S3 Bucket URL http://cloudx-aws-auto.s3-website-us-east-1.amazonaws.com/
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: node-in-aws-web
+service: cloudx-aws-auto
 
 frameworkVersion: '2'
 
@@ -17,12 +17,14 @@ plugins:
 
 custom:
   client:
-    bucketName: node-in-aws-web-bucket
+    bucketName: cloudx-aws-auto
     distributionFolder: build
   s3BucketName: ${self:custom.client.bucketName}
 
   ## Serverless-single-page-app-plugin configuration:
   s3LocalPath: ${self:custom.client.distributionFolder}/
+  # seems like region is not working, us-east-1 anyway
+  region: eu-west-1
 
 resources:
   Resources:

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -41,7 +41,7 @@ const MainLayout: React.FC = ({children}) => {
       </main>
       <footer className={classes.footer}>
         <Typography variant="subtitle1" align="center" color="textSecondary" component="p">
-          Thank you for your purchase!
+          Thank you for your purchase! Change from serverless-single-page-plugin
         </Typography>
         <Copyright/>
       </footer>


### PR DESCRIPTION
All 3 tasks were fulfilled (2.1, 2.2 and 2.3) for 5 points. 

CloudFront URL https://d1bmxna8i2i9rw.cloudfront.net/
S3 Bucket URL http://cloudx-aws-auto.s3-website-us-east-1.amazonaws.com/

AWS Infrastructure for 2.1 and 2.2 was removed intentionally (_Destroy created AWS infrastructure (S3 bucket and CloudFront distribution) from the previous part and steps. Make sure nothing is left._)

Changes for 2.3 are really small because scripts were already in the cloned repository (_Add necessary npm script(s) to build, upload to your S3 bucket, and invalidate CloudFront cache from your machine in an automated way._)